### PR TITLE
Add Granular Model Validation

### DIFF
--- a/roxfile.yml
+++ b/roxfile.yml
@@ -57,12 +57,8 @@ tasks:
   # Release-related
   - name: build-release-binary
     description: "Build a release binary with cargo."
+    command: "cargo build --release"
 
   - name: build-release-image
     description: "Build a production image for Docker."
     command: "docker build tests/files/ -t rox:latest"
-
-  # This won't show up in the CLI help output
-  - name: invalid
-    description: "This task will throw an error becasue it has nothing to do!"
-    hide: true

--- a/roxfile.yml
+++ b/roxfile.yml
@@ -57,7 +57,6 @@ tasks:
   # Release-related
   - name: build-release-binary
     description: "Build a release binary with cargo."
-    command: "cargo build --release"
 
   - name: build-release-image
     description: "Build a production image for Docker."

--- a/roxfile.yml
+++ b/roxfile.yml
@@ -11,7 +11,7 @@ file_requirements:
 
 templates:
   - name: docker_build
-    command: "docker build {path} -t rox:{image_tag}"
+    command: "docker build {pat} -t rox:{image_tag}"
     symbols: ["{path}", "{image_tag}"]
 
 pipelines:

--- a/roxfile.yml
+++ b/roxfile.yml
@@ -11,7 +11,7 @@ file_requirements:
 
 templates:
   - name: docker_build
-    command: "docker build {pat} -t rox:{image_tag}"
+    command: "docker build {path} -t rox:{image_tag}"
     symbols: ["{path}", "{image_tag}"]
 
 pipelines:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ mod cli;
 mod execution;
 mod file_requirements;
 mod model_injection;
-mod models;
+pub mod models;
 mod output;
 mod utils;
 mod version_requirements;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod version_requirements;
 use crate::cli::{cli_builder, construct_cli};
 use crate::execution::{execute_stages, execute_tasks, PassFail, TaskResult};
 use crate::model_injection::{inject_task_metadata, inject_template_values};
+use crate::models::Validate;
 use std::collections::HashMap;
 use std::error::Error;
 
@@ -35,6 +36,7 @@ pub fn rox() -> RoxResult<()> {
     // Get the file arg from the CLI if set
     let file_path = get_filepath();
     let roxfile = utils::parse_file_contents(utils::load_file(&file_path));
+    roxfile.validate()?;
     utils::print_horizontal_rule();
 
     // Build & Generate the CLI based on the loaded Roxfile

--- a/src/models.rs
+++ b/src/models.rs
@@ -124,6 +124,25 @@ pub struct Template {
     pub command: String,
     pub symbols: Vec<String>,
 }
+impl Validate for Template {
+    fn validate(&self) -> Result<(), ValidationError> {
+        let failure_message = format!("> Template '{}' failed validation!", self.name);
+
+        // All of the 'Symbol' items must exist within the 'Command'
+        for symbol in self.symbols.clone() {
+            let exists = self.command.contains(&symbol);
+            if !exists {
+                color_print(vec![failure_message], ColorEnum::Red);
+                return Err(ValidationError {
+                    message: "A Template's 'symbols' must all exist within its 'command'!"
+                        .to_owned(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
 
 /// Schema for Pipelines
 ///
@@ -155,6 +174,13 @@ impl Validate for RoxFile {
         for task in roxfile.tasks {
             task.validate()?
         }
+
+        if let Some(templates) = roxfile.templates {
+            for template in templates {
+                template.validate()?
+            }
+        }
+
         Ok(())
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,7 +2,10 @@
 //! as well as the validation logic.
 use serde::Deserialize;
 
-// TODO: Add broad validation to each struct
+// Trait for granular schema validation
+pub trait Validate {
+    fn validate(&self) -> Self;
+}
 
 /// Schema for Version Requirement Checks
 ///
@@ -30,10 +33,6 @@ pub struct FileRequirement {
     pub create_if_not_exists: Option<bool>,
 }
 
-pub trait Validate {
-    fn validate(&self);
-}
-
 /// Schema for Tasks in the Roxfile
 ///
 /// Tasks are discrete units of execution
@@ -49,6 +48,16 @@ pub struct Task {
     pub values: Option<Vec<String>>,
     pub hide: Option<bool>,
     pub workdir: Option<String>,
+}
+
+impl Validate for Task {
+    fn validate(&self) -> Self {
+        let validated_task = self.clone();
+        if validated_task.command.is_none() {
+            panic!("The task doesn't have a valid command!")
+        }
+        validated_task
+    }
 }
 
 /// Schema for Templates
@@ -85,4 +94,12 @@ pub struct RoxFile {
     pub pipelines: Option<Vec<Pipeline>>,
     pub templates: Option<Vec<Template>>,
     pub additional_files: Option<Vec<String>>,
+}
+
+impl Validate for RoxFile {
+    fn validate(&self) -> Self {
+        let mut validated_roxfile = self.clone();
+        validated_roxfile.tasks = self.tasks.iter().map(|task| task.validate()).collect();
+        validated_roxfile
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 //! Utility Functions
-use crate::models::{RoxFile, Validate};
+use crate::models::RoxFile;
 use std::fmt::Display;
 
 use colored::Colorize;
@@ -12,7 +12,6 @@ pub fn load_file(file_path: &str) -> String {
 /// Parse a Roxfile into Rust structs
 pub fn parse_file_contents(contents: String) -> RoxFile {
     let roxfile: RoxFile = serde_yaml::from_str(&contents).expect("Failed to parse the Roxfile!");
-    roxfile.validate();
     roxfile
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 //! Utility Functions
-use crate::models::RoxFile;
+use crate::models::{RoxFile, Validate};
 use std::fmt::Display;
 
 use colored::Colorize;
@@ -11,7 +11,9 @@ pub fn load_file(file_path: &str) -> String {
 
 /// Parse a Roxfile into Rust structs
 pub fn parse_file_contents(contents: String) -> RoxFile {
-    serde_yaml::from_str(&contents).expect("Failed to parse the Roxfile!")
+    let roxfile: RoxFile = serde_yaml::from_str(&contents).expect("Failed to parse the Roxfile!");
+    roxfile.validate();
+    roxfile
 }
 
 pub enum ColorEnum {

--- a/tests/models.rs
+++ b/tests/models.rs
@@ -1,88 +1,89 @@
-use rox::models::{Task, Validate};
-
-fn build_default_task() -> Task {
-    Task {
-        name: String::from("test_task"),
-        command: Some(String::from("some command")),
-        uses: None,
-        description: Some(String::from("This is a test task")),
-        workdir: Some(String::from("rox/")),
-        file_path: Some(String::from("some_filepath.yml")),
-        values: None,
-        hide: Some(false),
+mod tasks {
+    use rox::models::{Task, Validate};
+    fn build_default_task() -> Task {
+        Task {
+            name: String::from("test_task"),
+            command: Some(String::from("some command")),
+            uses: None,
+            description: Some(String::from("This is a test task")),
+            workdir: Some(String::from("rox/")),
+            file_path: Some(String::from("some_filepath.yml")),
+            values: None,
+            hide: Some(false),
+        }
     }
-}
 
-#[test]
-fn valid_task_ok() {
-    let task = build_default_task();
-    assert!(task.validate().is_ok());
-}
+    #[test]
+    fn valid_task_ok() {
+        let task = build_default_task();
+        assert!(task.validate().is_ok());
+    }
 
-#[test]
-fn task_no_command_no_uses() {
-    let mut task = build_default_task();
-    task.command = None;
-    task.uses = None;
+    #[test]
+    fn task_no_command_no_uses() {
+        let mut task = build_default_task();
+        task.command = None;
+        task.uses = None;
 
-    assert!(task.uses.is_none());
-    assert!(task.command.is_none());
-    assert!(task.values.is_none());
+        assert!(task.uses.is_none());
+        assert!(task.command.is_none());
+        assert!(task.values.is_none());
 
-    let result = task.validate();
-    assert!(result.is_err());
-    assert!(result.is_err_and(|e| e.message == "A Task must implement either 'command' or 'uses'!"));
-}
+        let result = task.validate();
+        assert!(result.is_err());
+        assert!(
+            result.is_err_and(|e| e.message == "A Task must implement either 'command' or 'uses'!")
+        );
+    }
 
-#[test]
-fn task_has_command_and_uses() {
-    let mut task = build_default_task();
-    task.uses = task.command.clone();
+    #[test]
+    fn task_has_command_and_uses() {
+        let mut task = build_default_task();
+        task.uses = task.command.clone();
 
-    // Confirm test setup
-    assert!(task.uses.is_some());
-    assert!(task.command.is_some());
-    assert!(task.values.is_none());
+        // Confirm test setup
+        assert!(task.uses.is_some());
+        assert!(task.command.is_some());
+        assert!(task.values.is_none());
 
-    let result = task.validate();
-    assert!(result.is_err());
-    assert!(result.is_err_and(|e| e.message == "A Task cannot implement both 'command' & 'uses'!"));
-}
+        let result = task.validate();
+        assert!(result.is_err());
+        assert!(
+            result.is_err_and(|e| e.message == "A Task cannot implement both 'command' & 'uses'!")
+        );
+    }
 
-#[test]
-fn task_has_uses_no_values() {
-    let mut task = build_default_task();
-    task.uses = task.command;
-    task.command = None;
+    #[test]
+    fn task_has_uses_no_values() {
+        let mut task = build_default_task();
+        task.uses = task.command;
+        task.command = None;
 
-    // Confirm test setup
-    assert!(task.uses.is_some());
-    assert!(task.command.is_none());
-    assert!(task.values.is_none());
+        // Confirm test setup
+        assert!(task.uses.is_some());
+        assert!(task.command.is_none());
+        assert!(task.values.is_none());
 
-    let result = task.validate();
-    assert!(result.is_err());
-    assert!(
-        result.is_err_and(
+        let result = task.validate();
+        assert!(result.is_err());
+        assert!(result.is_err_and(
             |e| e.message == "A Task that implements 'uses' must also implement 'values'!"
-        )
-    );
-}
+        ));
+    }
 
-#[test]
-fn task_has_values_no_uses() {
-    let mut task = build_default_task();
-    task.values = Some(vec!["test".to_owned()]);
+    #[test]
+    fn task_has_values_no_uses() {
+        let mut task = build_default_task();
+        task.values = Some(vec!["test".to_owned()]);
 
-    // Confirm test setup
-    assert!(task.uses.is_none());
-    assert!(task.values.is_some());
+        // Confirm test setup
+        assert!(task.uses.is_none());
+        assert!(task.values.is_some());
 
-    let result = task.validate();
-    assert!(result.is_err());
-    assert!(
-        result.is_err_and(
+        let result = task.validate();
+        assert!(result.is_err());
+        assert!(result.is_err_and(
             |e| e.message == "A Task that implements 'values' must also implement 'uses'!"
-        )
-    );
+        ));
+    }
 }

--- a/tests/models.rs
+++ b/tests/models.rs
@@ -87,3 +87,33 @@ mod tasks {
         ));
     }
 }
+
+mod templates {
+    use rox::models::{Template, Validate};
+
+    fn build_default_template() -> Template {
+        Template {
+            name: String::from("test_task"),
+            command: String::from("docker build {path}"),
+            symbols: vec!["{path}".to_owned()],
+        }
+    }
+
+    #[test]
+    fn valid_template_ok() {
+        let template = build_default_template();
+        assert!(template.validate().is_ok());
+    }
+
+    #[test]
+    fn template_symbols_not_in_command() {
+        let mut template = build_default_template();
+        template.command = "some string".to_owned();
+
+        let result = template.validate();
+        assert!(result.is_err());
+        assert!(result.is_err_and(
+            |e| e.message == "A Template's 'symbols' must all exist within its 'command'!"
+        ));
+    }
+}

--- a/tests/models.rs
+++ b/tests/models.rs
@@ -1,0 +1,88 @@
+use rox::models::{Task, Validate};
+
+fn build_default_task() -> Task {
+    Task {
+        name: String::from("test_task"),
+        command: Some(String::from("some command")),
+        uses: None,
+        description: Some(String::from("This is a test task")),
+        workdir: Some(String::from("rox/")),
+        file_path: Some(String::from("some_filepath.yml")),
+        values: None,
+        hide: Some(false),
+    }
+}
+
+#[test]
+fn valid_task_ok() {
+    let task = build_default_task();
+    assert!(task.validate().is_ok());
+}
+
+#[test]
+fn task_no_command_no_uses() {
+    let mut task = build_default_task();
+    task.command = None;
+    task.uses = None;
+
+    assert!(task.uses.is_none());
+    assert!(task.command.is_none());
+    assert!(task.values.is_none());
+
+    let result = task.validate();
+    assert!(result.is_err());
+    assert!(result.is_err_and(|e| e.message == "A Task must implement either 'command' or 'uses'!"));
+}
+
+#[test]
+fn task_has_command_and_uses() {
+    let mut task = build_default_task();
+    task.uses = task.command.clone();
+
+    // Confirm test setup
+    assert!(task.uses.is_some());
+    assert!(task.command.is_some());
+    assert!(task.values.is_none());
+
+    let result = task.validate();
+    assert!(result.is_err());
+    assert!(result.is_err_and(|e| e.message == "A Task cannot implement both 'command' & 'uses'!"));
+}
+
+#[test]
+fn task_has_uses_no_values() {
+    let mut task = build_default_task();
+    task.uses = task.command;
+    task.command = None;
+
+    // Confirm test setup
+    assert!(task.uses.is_some());
+    assert!(task.command.is_none());
+    assert!(task.values.is_none());
+
+    let result = task.validate();
+    assert!(result.is_err());
+    assert!(
+        result.is_err_and(
+            |e| e.message == "A Task that implements 'uses' must also implement 'values'!"
+        )
+    );
+}
+
+#[test]
+fn task_has_values_no_uses() {
+    let mut task = build_default_task();
+    task.values = Some(vec!["test".to_owned()]);
+
+    // Confirm test setup
+    assert!(task.uses.is_none());
+    assert!(task.values.is_some());
+
+    let result = task.validate();
+    assert!(result.is_err());
+    assert!(
+        result.is_err_and(
+            |e| e.message == "A Task that implements 'values' must also implement 'uses'!"
+        )
+    );
+}


### PR DESCRIPTION
### Code Changes

The goal here is to add custom validation logic directly to each struct using a new trait. This gives the ability to surface much more helpful error messages!

The new implementation will see `.validate()` added as a method to existing models, which returns either `()` or the new `ValidationError` result

* [x] add a new Trait or validation
* [x] add test scaffolding + tests for the new validation logic
* [x] implement the trait and add validation logic to the following models:
  * [x] `Task`
  * [x] `VersionRequirements`
  * [x] `Templates`