### PR TITLE
Update `rox` commands to use `sh` to run arbitrary commands

### DIFF
--- a/rox.code-workspace
+++ b/rox.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"rust-analyzer.linkedProjects": [
+			"./Cargo.toml"
+		]
+	}
+}

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -1,6 +1,5 @@
 //! This is the module responsible for executing tasks.
 use crate::models::Task;
-use crate::utils;
 use std::collections::HashMap;
 use std::process::{Command, ExitStatus};
 
@@ -43,12 +42,13 @@ pub fn run_task(task: &Task) -> TaskResult {
     let start = std::time::Instant::now();
 
     let workdir = task.workdir.clone().unwrap_or(".".to_string());
+    let command = task.command.as_ref().unwrap();
 
-    println!("> Running command: '{}'", task.command.as_ref().unwrap());
-    let (command, args) = utils::split_head_from_rest(task.command.as_ref().unwrap());
-    let command_results = Command::new(command)
+    println!("> Running command: '{}'", command);
+    let command_results = Command::new("sh")
         .current_dir(workdir)
-        .args(args)
+        .arg("-c")
+        .arg(command)
         .status();
 
     TaskResult {


### PR DESCRIPTION
I was running into a problem while using `rox` where more complex commands like `cargo watch -c -x 'run server'` wouldn't work because of the way that the arguments were being passed to the command. The method of forcing `sh -c` seems to fix it!

Note: the documentation [specifically calls out](https://doc.rust-lang.org/std/process/struct.Command.html#method.args) that things like globs and strings don't work in args